### PR TITLE
feat : implement ls-tree without option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Let's implement the git command to learn the internals of git..
 
 ## TODO 
 
-- git 은 Plumbing Commands 와 Porcelain Commands 로 나뉜다. (`git help -av | man git`)
+> git 은 Plumbing Commands 와 Porcelain Commands 로 나뉜다. (`git help -av` or `man git` 참고)
 
 ### git options
 
@@ -23,6 +23,8 @@ Let's implement the git command to learn the internals of git..
   - [x] without options
 - [ ] `git check-ignore`
   - [x] without options
+- [ ] `git ls-tree`
+  - [ ] without options
 - [ ] `git update-index`
 - [ ] `git write-tree`
 - [ ] `git read-tree`

--- a/src/adapters/command_executor.rs
+++ b/src/adapters/command_executor.rs
@@ -17,8 +17,7 @@ use crate::{
       ls_files::LsFiles,
     },
     core::{
-      ignore_service::IgnoreServiceImpl, object_service::ObjectService,
-      object_service::ObjectServiceImpl,
+      ignore_service::IgnoreServiceImpl, object_service::ObjectServiceImpl,
     },
   },
 };

--- a/src/adapters/command_executor.rs
+++ b/src/adapters/command_executor.rs
@@ -15,6 +15,7 @@ use crate::{
       init,
       log::{Log, LogOptions},
       ls_files::LsFiles,
+      ls_tree::{LsTree, LsTreeOptions},
     },
     core::{
       ignore_service::IgnoreServiceImpl, object_service::ObjectServiceImpl,
@@ -140,6 +141,22 @@ impl CommandExecutor {
 
         let result =
           Log::new(store.as_ref(), &object_service, options).run()?;
+
+        println!("{}", result);
+        Ok(())
+      }
+      Commands::LsTree(ls_tree_args) => {
+        trace!("LsTree");
+
+        let result = LsTree::new(
+          &object_service,
+          LsTreeOptions {
+            recurse: ls_tree_args.recurse,
+            tree_ish: ls_tree_args.tree_ish,
+            path: ls_tree_args.path,
+          },
+        )
+        .run()?;
 
         println!("{}", result);
         Ok(())

--- a/src/cli/parser.rs
+++ b/src/cli/parser.rs
@@ -149,8 +149,8 @@ pub struct LogArgs {
   #[arg(long = "oneline", default_value = "false")]
   pub is_oneline: bool,
 
-  #[arg(long = "abbrev-commit", default_value = "7")]
-  pub abbrev_commit: u8,
+  #[arg(long = "abbrev-commit")]
+  pub abbrev_commit: Option<u8>,
 
   #[arg(long = "no-abbrev-commit", default_value = "false")]
   pub no_abbrev_commit: bool,

--- a/src/cli/parser.rs
+++ b/src/cli/parser.rs
@@ -55,13 +55,12 @@ pub enum Commands {
     object: String,
   },
   LsFiles {},
-
   CheckIgnore {
     #[arg(value_name = "paths")]
     paths: Vec<String>,
   },
-
   Log(LogArgs),
+  LsTree(LsTreeArgs),
   /// Clones repos
   #[command(arg_required_else_help = true)]
   Clone {
@@ -157,6 +156,19 @@ pub struct LogArgs {
 
   #[arg(long = "stat", default_value = "false")]
   pub stat: bool,
+}
+
+#[derive(Debug, Args, PartialEq, Eq)]
+#[command(args_conflicts_with_subcommands = true)]
+pub struct LsTreeArgs {
+  #[arg(short = 'r')]
+  pub recurse: bool,
+
+  #[arg(value_name = "tree-ish", required = true)]
+  pub tree_ish: String,
+
+  #[arg(value_name = "path")]
+  pub path: Vec<String>,
 }
 
 #[derive(Debug, Args, PartialEq, Eq)]

--- a/src/entities/object.rs
+++ b/src/entities/object.rs
@@ -17,12 +17,12 @@ impl Object {
   }
 }
 
-pub struct BlobObject {
-  pub object_type: String,
-  pub data: Vec<u8>,
-  pub hash: String,
-  pub size: usize,
-}
+// pub struct BlobObject {
+//   pub object_type: String,
+//   pub data: Vec<u8>,
+//   pub hash: String,
+//   pub size: usize,
+// }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TreeObject {
@@ -75,13 +75,10 @@ impl TreeObject {
       if hash_end > content_len {
         return Err("Incomplete hash".into());
       }
-      let hash =
-        std::str::from_utf8(&content[hash_start..hash_end]).map_err(|_| {
-          format!(
-            "Failed to parse hash as UTF-8: {:?}",
-            &content[hash_start..hash_end]
-          )
-        })?;
+      let hash = &content[hash_start..hash_end]
+        .iter()
+        .map(|b| format!("{:02x}", b))
+        .collect::<String>();
 
       entries.push(TreeElement {
         mode: mode.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use log::{debug, error, info, trace, warn};
+use log::{error, trace};
 
 use crate::{
   adapters::command_executor::{CommandExecutionContext, CommandExecutor},
@@ -13,11 +13,6 @@ mod use_cases;
 
 fn main() -> Result<(), String> {
   env_logger::init();
-  // trace!("trace");
-  // warn!("warn");
-  // info!("info");
-  // debug!("debug");
-  // error!("error");
 
   let args = Cli::parse();
   trace!("args: {:?}", args);

--- a/src/use_cases/commands/ls_tree.rs
+++ b/src/use_cases/commands/ls_tree.rs
@@ -1,0 +1,57 @@
+use log::trace;
+
+use crate::{
+  entities::object::TreeObject, use_cases::core::object_service::ObjectService,
+};
+
+#[derive(Debug)]
+pub struct LsTreeOptions {
+  pub recurse: bool,
+  pub tree_ish: String,
+  pub path: Vec<String>,
+}
+
+pub struct LsTree<'a> {
+  object_service: &'a dyn ObjectService,
+  options: LsTreeOptions,
+}
+
+impl<'a> LsTree<'a> {
+  pub fn new(
+    object_service: &'a dyn ObjectService,
+    options: LsTreeOptions,
+  ) -> Self {
+    return Self {
+      object_service,
+      options,
+    };
+  }
+
+  pub fn run(&self) -> Result<String, String> {
+    trace!("LsTree: {:?}", self.options);
+
+    let raw_object = self.object_service.find(&self.options.tree_ish)?;
+    let tree = TreeObject::parse(&self.options.tree_ish, &raw_object.data)?;
+    trace!("tree: {:?}", tree);
+    let result = tree
+      .entries
+      .iter()
+      .map(|entry| match entry.mode.as_str() {
+        "40000" => {
+          format!("{} {} {}\t{}\n", "040000", "tree", entry.hash, entry.name)
+        }
+        _ => {
+          format!("{} {} {}\t{}\n", entry.mode, "blob", entry.hash, entry.name)
+        }
+      })
+      .collect::<Vec<String>>()
+      .join("");
+
+    // let mut result = String::new();
+    // for (name, hash) in tree.entries.iter() {
+    //   let object = self.object_service.find(hash)?;
+    //   result.push_str(&format!("{}\t{}\t{}\n", object.object_type, hash, name));
+    // }
+    Ok(result)
+  }
+}

--- a/src/use_cases/commands/ls_tree.rs
+++ b/src/use_cases/commands/ls_tree.rs
@@ -1,7 +1,8 @@
 use log::trace;
 
 use crate::{
-  entities::object::TreeObject, use_cases::core::object_service::ObjectService,
+  entities::object::{TreeElement, TreeObject},
+  use_cases::core::object_service::ObjectService,
 };
 
 #[derive(Debug)]
@@ -33,17 +34,21 @@ impl<'a> LsTree<'a> {
     let raw_object = self.object_service.find(&self.options.tree_ish)?;
     let tree = TreeObject::parse(&self.options.tree_ish, &raw_object.data)?;
     trace!("tree: {:?}", tree);
-    let result = tree
-      .entries
-      .iter()
-      .map(|entry| match entry.mode.as_str() {
+
+    let formatter = |entry: &TreeElement| -> String {
+      match entry.mode.as_str() {
         "40000" => {
           format!("{} {} {}\t{}\n", "040000", "tree", entry.hash, entry.name)
         }
         _ => {
           format!("{} {} {}\t{}\n", entry.mode, "blob", entry.hash, entry.name)
         }
-      })
+      }
+    };
+    let result = tree
+      .entries
+      .iter()
+      .map(formatter)
       .collect::<Vec<String>>()
       .join("");
 

--- a/src/use_cases/commands/mod.rs
+++ b/src/use_cases/commands/mod.rs
@@ -5,4 +5,5 @@ pub mod hash_object;
 pub mod init;
 pub mod log;
 pub mod ls_files;
+pub mod ls_tree;
 pub mod utils;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

- New Feature: Introduced the `ls-tree` command, enhancing the software's functionality by allowing users to list the contents of a tree object in a version control system. This feature provides a more comprehensive view of the system's structure.
- Improvement: Updated the `log` command with more flexible formatting options, including the ability to abbreviate commit hashes and display only the first line of commit messages. This makes the output more customizable and easier to read.
- Documentation: Clarified the usage of `git help -av` and `man git` commands in the README, improving the guidance for new users.
- Refactor: Removed unnecessary logging and simplified the main function, enhancing the software's maintainability and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->